### PR TITLE
Fix project init script + gh action

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -49,6 +49,7 @@ jobs:
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3
+        continue-on-error: true
         with:
           files: coverage.xml
-          fail_ci_if_error: true
+          fail_ci_if_error: false

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -36,16 +36,16 @@ jobs:
           fi
           
       - name: Run Linter
-        run: uv pip run ruff check --fix ${{ steps.module.outputs.name }}
+        run: uv run -m ruff check --fix ${{ steps.module.outputs.name }}
         
       - name: Run Formatter
-        run: uv pip run ruff format ${{ steps.module.outputs.name }}
+        run: uv run -m ruff format ${{ steps.module.outputs.name }}
         
       - name: Run Tests
-        run: uv pip run pytest tests --cov=${{ steps.module.outputs.name }} --cov-report=term-missing --cov-report=xml
+        run: uv run -m pytest tests --cov=${{ steps.module.outputs.name }} --cov-report=term-missing --cov-report=xml
         
       - name: Run MyPy
-        run: uv pip run mypy ${{ steps.module.outputs.name }}
+        run: uv run -m mypy ${{ steps.module.outputs.name }}
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,19 +22,30 @@ jobs:
         run: |
           uv pip compile pyproject.toml -o requirements.txt
           uv pip compile pyproject.toml --extra dev -o requirements-dev.txt
+          uv venv
           uv pip sync requirements.txt requirements-dev.txt
           
-      - name: Run MyPy
-        run: uv pip run mypy src
-        
+      - name: Determine module name
+        id: module
+        run: |
+          if [ -d "src" ]; then
+            echo "name=src" >> $GITHUB_OUTPUT
+          else
+            MODULE_NAME=$(basename $(find . -maxdepth 1 -type d -not -path "*/\.*" -not -path "./tests" -not -path "./scripts" -not -path "./docker" -not -path "." | sort | head -1))
+            echo "name=$MODULE_NAME" >> $GITHUB_OUTPUT
+          fi
+          
       - name: Run Linter
-        run: uv pip run ruff check src
+        run: uv pip run ruff check --fix ${{ steps.module.outputs.name }}
         
       - name: Run Formatter
-        run: uv pip run ruff format src
+        run: uv pip run ruff format ${{ steps.module.outputs.name }}
         
       - name: Run Tests
-        run: uv pip run pytest tests --cov=src --cov-report=term-missing --cov-report=xml
+        run: uv pip run pytest tests --cov=${{ steps.module.outputs.name }} --cov-report=term-missing --cov-report=xml
+        
+      - name: Run MyPy
+        run: uv pip run mypy ${{ steps.module.outputs.name }}
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ docker/.env
 .pytest_cache/*
 .ruff_cache/*
 .aider*
+CLAUDE.md

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,12 +1,6 @@
 repos:
 -   repo: local
     hooks:
-    -   id: mypy
-        name: Run MyPy
-        entry: make mypy
-        language: system
-        always_run: true
-        pass_filenames: false
     -   id: lint
         name: Run Linter
         entry: make lint
@@ -22,6 +16,12 @@ repos:
     -   id: test
         name: Run Tests
         entry: make test
+        language: system
+        always_run: true
+        pass_filenames: false
+    -   id: mypy
+        name: Run MyPy
+        entry: make mypy
         language: system
         always_run: true
         pass_filenames: false

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,8 @@
 .PHONY: compile-deps setup clean-pyc clean-test clean-venv clean test mypy lint format check clean-example dev-env refresh-containers rebuild-images build-image push-image
 
+# Module name - will be updated by init script
+MODULE_NAME := src
+
 # Development Setup
 #################
 compile-deps:  # Compile dependencies from pyproject.toml
@@ -46,18 +49,18 @@ clean: clean-pyc clean-test clean-venv
 # Testing and Quality Checks
 #########################
 test: setup  # Run pytest with coverage
-	uv run -m pytest tests --cov=src --cov-report=term-missing
+	uv run -m pytest tests --cov=$(MODULE_NAME) --cov-report=term-missing
 
 mypy: setup  # Run type checking
-	uv run -m mypy src
+	uv run -m mypy $(MODULE_NAME)
 
-lint: setup  # Run ruff linter
-	uv run -m ruff check src
+lint: setup  # Run ruff linter with auto-fix
+	uv run -m ruff check --fix $(MODULE_NAME)
 
 format: setup  # Run ruff formatter
-	uv run -m ruff format src
+	uv run -m ruff format $(MODULE_NAME)
 
-check: setup test mypy lint format  # Run all quality checks
+check: setup lint format test mypy  # Run all quality checks
 
 # Project Management
 ##################


### PR DESCRIPTION
  - Fixed module name updating during project init to correctly replace src with project-specific module
  - Updated GitHub Actions workflow to create virtual environment before installing dependencies
  - Reordered quality checks for faster feedback (lint → format → test → mypy)
  - Added auto-fix to linter for automatic code corrections
  - Bypassed pre-commit hooks for initial commit to prevent failures with empty projects
  - Made Codecoverage upload CI optional since most repos won't have that set up

  Test plan

  Initialize new project with different naming options and verify module structure, test execution, and GitHub workflow functionality.
