### PR TITLE
Add Claude Code integration to Docker development environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ A modern Python project template with best practices for development and collabo
 - 🔍 Type checking with [mypy](https://github.com/python/mypy)
 - 🧪 Testing with [pytest](https://github.com/pytest-dev/pytest)
 - 🐳 Docker support for development and deployment
+- 🤖 Claude Code integration for AI-assisted development
 - 👷 CI/CD with GitHub Actions
 
 ## Python Version
@@ -109,6 +110,34 @@ This creates a container with:
 - Source code mounted (changes reflect immediately)
 - Development tools ready to use
 - Automatic UID/GID mapping for file permissions
+- Claude Code CLI for AI-assisted development
+
+#### Using Claude Code in the Container
+
+1. Set up your API key:
+```bash
+# Copy the environment template
+cp docker/template.env docker/.env
+
+# Add your Anthropic API key to docker/.env
+echo "ANTHROPIC_API_KEY=your_api_key_here" >> docker/.env
+```
+
+2. Start the development environment:
+```bash
+make dev-env
+```
+
+3. Inside the container, use Claude Code:
+```bash
+# Interactive mode (asks for permission before each action)
+claude
+
+# Autonomous mode (runs without permission prompts)
+claude --dangerously-skip-permissions
+```
+
+**Note**: The `--dangerously-skip-permissions` flag allows Claude to work autonomously. Use with caution and always review changes before committing.
 
 ### Production Image
 ```bash

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.12-slim
 
-# Install Auxiliary Software
+# Install Auxiliary Software + Node.js for Claude Code
 RUN apt-get update && apt-get install -y \
     make \
     apt-utils \
@@ -12,7 +12,12 @@ RUN apt-get update && apt-get install -y \
     graphviz \
     software-properties-common \
     vim \
+    && curl -fsSL https://deb.nodesource.com/setup_18.x | bash - \
+    && apt-get install -y nodejs \
     && rm -rf /var/lib/apt/lists/*
+
+# Install Claude Code CLI
+RUN npm install -g @anthropic-ai/claude-code
 
 WORKDIR /workspace
 

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -10,6 +10,7 @@ services:
     environment:
       EXAMPLE: ${EXAMPLE}
       EXAMPLE_SECRET: ${EXAMPLE_SECRET}
+      ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY}
     command: /bin/bash
     # Note: user mapping handled by Podman rootless automatically
     # Bind whole project directory for simplicity  

--- a/docker/template.env
+++ b/docker/template.env
@@ -8,6 +8,7 @@ DEBUG=true
 # Secrets (do not commit actual values)
 API_KEY=
 DATABASE_URL=
+ANTHROPIC_API_KEY=
 
 # Container runtime settings (optional)
 # UID=${UID}  # Uncomment to use your system UID


### PR DESCRIPTION
# Status: See below comment, this will remain an open PR for use as a template to clone from unless there is further desire to fully integrate Claude Code

## Summary

Adds Claude Code CLI to the development container so developers can use AI assistance directly in their containerized environment, with full Podman/Docker compatibility.

## Changes
**Container Integration**
- Added Node.js and Claude Code CLI to development Dockerfile
- Environment variable support for ANTHROPIC_API_KEY in docker-compose
- Works seamlessly with both Docker and Podman engines
- Integrated with the new container engine detection system

**Developer Experience**  
- Simple setup: copy template.env, add API key, run make dev-env
- Two modes: interactive (with permission prompts) or autonomous (with --dangerously-skip-permissions)
- Works alongside existing development tools in the container
- Automatic container engine detection (Podman preferred, Docker fallback)

**Documentation**
- Updated README with Claude Code setup instructions
- Clear usage examples for both interaction modes
- Integration with container compatibility documentation

## Compatibility
- ✅ Works with Docker and Podman
- ✅ Survives `make init` project restructuring
- ✅ Maintains existing container workflow
- ✅ No changes to core development commands

This keeps the 80/20 approach - just adding Claude as another dev tool rather than complex isolation setups, while leveraging the robust container compatibility infrastructure.